### PR TITLE
[IT-1261] Small updates

### DIFF
--- a/.github/workflows/autopkg-run.yml
+++ b/.github/workflows/autopkg-run.yml
@@ -15,7 +15,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/autopkg-run.yml
+++ b/.github/workflows/autopkg-run.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 6 * * MON-Fri'
   workflow_dispatch:
+    inputs:
+      recipes:
+        description: List of recipes to run separated by spaces
+        required: False
 
 jobs:
   autopkg-run:

--- a/.github/workflows/autopkg-run.yml
+++ b/.github/workflows/autopkg-run.yml
@@ -24,9 +24,9 @@ jobs:
       
       - name: Install Munki
         run: |
-          curl -OL https://github.com/munki/munki/releases/download/v5.5.0/munkitools-5.5.0.4362.pkg
-          sudo installer -pkg munkitools-5.5.0.4362.pkg -target /
-          sudo rm munkitools-5.5.0.4362.pkg
+          curl -OL https://github.com/munki/munki/releases/download/v5.6.3/munkitools-5.6.3.4401.pkg
+          sudo installer -pkg munkitools-5.6.3.4401.pkg -target /
+          sudo rm munkitools-5.6.3.4401.pkg
       
       - name: Install AutoPkg
         run: |

--- a/.github/workflows/autopkg-run.yml
+++ b/.github/workflows/autopkg-run.yml
@@ -57,3 +57,4 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RECIPES: ${{ github.event.inputs.recipes }}

--- a/.github/workflows/clean-repo.yml
+++ b/.github/workflows/clean-repo.yml
@@ -16,9 +16,9 @@ jobs:
     
       - name: Install Munki
         run: |
-          curl -OL https://github.com/munki/munki/releases/download/v5.5.1/munkitools-5.5.1.4365.pkg
-          sudo installer -pkg munkitools-5.5.1.4365.pkg -target /
-          sudo rm munkitools-5.5.1.4365.pkg
+          curl -OL https://github.com/munki/munki/releases/download/v5.6.3/munkitools-5.6.3.4401.pkg
+          sudo installer -pkg munkitools-5.6.3.4401.pkg -target /
+          sudo rm munkitools-5.6.3.4401.pkg
       
       - name: Run makecatalogs
         run: |

--- a/.github/workflows/clean-repo.yml
+++ b/.github/workflows/clean-repo.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
         with:
           fetch-depth: 1
     
@@ -29,7 +29,7 @@ jobs:
           /usr/local/munki/repoclean -a --keep 2 $GITHUB_WORKSPACE/munki_repo
       
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27 #v4.0.4
         with:
           branch: clean-munki-repo
           commit-message: Remove old pkgs and pkgsinfo

--- a/.github/workflows/sync-repo.yml
+++ b/.github/workflows/sync-repo.yml
@@ -26,9 +26,9 @@ jobs:
       
       - name: Install Munki
         run: |
-          curl -OL https://github.com/munki/munki/releases/download/v5.5.0/munkitools-5.5.0.4362.pkg
-          sudo installer -pkg munkitools-5.5.0.4362.pkg -target /
-          sudo rm munkitools-5.5.0.4362.pkg
+          curl -OL https://github.com/munki/munki/releases/download/v5.6.3/munkitools-5.6.3.4401.pkg
+          sudo installer -pkg munkitools-5.6.3.4401.pkg -target /
+          sudo rm munkitools-5.6.3.4401.pkg
     
       - name: Run makecatalogs
         run : |

--- a/.github/workflows/sync-repo.yml
+++ b/.github/workflows/sync-repo.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
         with:
           lfs: 'true'
           fetch-depth: 1
@@ -45,7 +45,7 @@ jobs:
     needs: sync-repo
     steps:
       - name: Send Slack notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 #v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_ICON: https://avatars.githubusercontent.com/u/8826633?s=200&v=4

--- a/.github/workflows/update-trust-info.yml
+++ b/.github/workflows/update-trust-info.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
 
       - name: Install AutoPkg
         run: |
@@ -53,7 +53,7 @@ jobs:
           autopkg update-trust-info ${{ github.event.inputs.recipe }}.munki.recipe
       
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27 #v4.0.4
         with:
           branch: update-${{ github.event.inputs.recipe }}-trust-info
           title: Update recipe trust info for ${{ github.event.inputs.recipe }}

--- a/autopkg/autopkg_tools.py
+++ b/autopkg/autopkg_tools.py
@@ -15,6 +15,7 @@ GIT = "/usr/bin/git"
 HUB = "/usr/local/bin/hub"
 REPO_DIR = os.environ['GITHUB_WORKSPACE'] + "/munki_repo"
 GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
+INPUT_RECIPES = os.environ['INPUT_RECIPES'].split()
 
 class Error(Exception):
   """Base class for domain-specific exceptions."""
@@ -227,7 +228,7 @@ def imported_message(imported):
         
 def failures_message(failed):
     """Format a list of failed recipes for a slack message"""
-    failures_msg = 	[            
+    failures_msg =  [              
         {
             "color": '#f2c744', "blocks": [
                 {
@@ -246,7 +247,7 @@ def failures_message(failed):
             {
                 "type": "section", "text": {"type": "mrkdwn", "text": f"{name}"}
             },
-            {					
+            {                   
                 "type": "section", "text": {"type": "mrkdwn", "text": f"```{info}```"}
             }
         ]
@@ -271,7 +272,7 @@ def git_errors_message(git_info):
         name = item['branch']
         info = item['error']
         git_info = [
-            {					
+            {                   
                 "type": "section", "text": {"type": "mrkdwn", "text": f"error pushing branch: {name} ```{info}```"}
             }
         ]
@@ -285,10 +286,10 @@ def format_slack_message(imported, failed, git_info):
         "attachments": [
             {
                 "color": "#4bb543","blocks": [
-                    {"type": "section","text": {"type": "mrkdwn","text": ":package: *AutoPkg has finished running*"}}				
+                    {"type": "section","text": {"type": "mrkdwn","text": ":package: *AutoPkg has finished running*"}}               
                 ]
             }          
-	    ]
+        ]
     }
     if not imported:
         msg_info = [
@@ -323,11 +324,14 @@ def autopkg_run(recipe):
     autopkg_cmd.append("report.plist")
     run_live(autopkg_cmd)
         
-def handle_recipes():    
-    recipes = get_recipes()
+def handle_recipes():
     imported = []
     failed = [] 
     git_errors = []
+    if INPUT_RECIPES:
+        recipes = INPUT_RECIPES
+    else:
+        recipes = get_recipes()
     for recipe in recipes:
         # Parse the recipe name for basic item name
         branchname = parse_recipe_name(recipe)


### PR DESCRIPTION
This PR reflects some small changes we made to our internal setup of serverless-munki at Ada which include:
- The ability to specify recipe names when triggering the autopkg-run workflow manually
- Switched version pinning on third-party Github actions from tags to SHA1 commit hashes
- Updated the version of munki used in actions runners